### PR TITLE
fix(windows): default destination is not displayed on Windows

### DIFF
--- a/src/store/file/file.utils.js
+++ b/src/store/file/file.utils.js
@@ -1,8 +1,9 @@
 export const getDirPathFromFilePath = filePath => {
-    const filePathArray = filePath.split('/');
+    const pathSeparator = navigator.platform === 'Win32' ? '\\' : '/';
+    const filePathArray = filePath.split(pathSeparator);
     filePathArray.pop();
 
-    return filePathArray.join('/');
+    return filePathArray.join(pathSeparator);
 };
 
 export const areFilesFromSameDirectory = files =>


### PR DESCRIPTION
Related issue #21 

## Description
In destination input, default destination is not displayed on Windows because of the path separator.
Check if the platform is windows and set the path separator accordingly: `\`

## How to test
Run the app on Windows and add a file, the default destination should be displayed

## Checklist
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] My change requires a change to the translations
- [ ] I have updated the translation files accordingly
