### PR TITLE
feat(files): add file streams info in a collapse panel

### DIFF
--- a/src/components/File/File.js
+++ b/src/components/File/File.js
@@ -1,23 +1,49 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import { Card, CardHeader, CircularProgress, LinearProgress, makeStyles } from '@material-ui/core';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CircularProgress,
+    Collapse,
+    LinearProgress,
+    makeStyles,
+} from '@material-ui/core';
 import CheckIcon from '@material-ui/icons/CheckCircle';
 import ErrorIcon from '@material-ui/icons/Error';
 import VideoIcon from '@material-ui/icons/MovieOutlined';
 import DeleteIcon from '@material-ui/icons/DeleteOutline';
+import ExpandIcon from '@material-ui/icons/ExpandMore';
 import IconButton from '../IconButton';
 import { FILE_STATUS } from '../../store/file/file.constants';
 import { getIsConversionRunning } from '../../store/conversion/conversion.selectors';
 import { formatFileSize } from '../../store/file/file.utils';
+import FileStreams from '../FileStreams';
 
 const useStyles = makeStyles(theme => ({
+    cardContent: {
+        marginBottom: theme.spacing(2),
+    },
+    expandButton: {
+        bottom: 4,
+        left: 0,
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        position: 'absolute',
+        right: 0,
+        transform: props => (props.expanded ? 'rotate(180deg)' : 'rotate(0deg)'),
+        transition: theme.transitions.create('transform', {
+            duration: theme.transitions.duration.shortest,
+        }),
+    },
     file: {
         '&:last-child': {
             marginBottom: 0,
         },
         marginBottom: theme.spacing(),
+        position: 'relative',
     },
     progressWrapper: {
         height: 4,
@@ -29,7 +55,8 @@ const useStyles = makeStyles(theme => ({
 
 const File = ({ file, onDeleteFile }) => {
     const { name, progress, size, status } = file;
-    const classes = useStyles();
+    const [expanded, setExpanded] = useState(false);
+    const classes = useStyles({ expanded });
     const { t } = useTranslation();
     const isConverting = status === FILE_STATUS.converting;
     const isConversionRunning = useSelector(getIsConversionRunning);
@@ -49,6 +76,8 @@ const File = ({ file, onDeleteFile }) => {
         }
     }, [classes.successIcon, status]);
 
+    const handleExpandClick = useCallback(() => setExpanded(!expanded), [expanded]);
+
     const deleteAction = (
         <IconButton disabled={deleteActionIsDisabled} label={t('removeFile')} onClick={onDeleteFile}>
             <DeleteIcon />
@@ -58,6 +87,14 @@ const File = ({ file, onDeleteFile }) => {
     return (
         <Card className={classes.file} variant="outlined">
             <CardHeader action={deleteAction} avatar={icon} title={name} subheader={fileSize} />
+            <IconButton className={classes.expandButton} onClick={handleExpandClick} size="small">
+                <ExpandIcon />
+            </IconButton>
+            <Collapse in={expanded} timeout="auto" unmountOnExit>
+                <CardContent className={classes.cardContent}>
+                    <FileStreams file={file} />
+                </CardContent>
+            </Collapse>
             <div className={classes.progressWrapper}>
                 {isConverting && <LinearProgress value={progress} variant="determinate" />}
             </div>

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -26,11 +26,13 @@ const useStyles = makeStyles(theme => ({
         flex: 1,
         height: '100%',
         position: 'relative',
+        width: 'calc(100% - 400px)',
     },
     filesWrapper: {
         height: '100%',
         overflow: 'auto',
         padding: theme.spacing(2),
+        paddingBottom: theme.spacing(8),
     },
 }));
 
@@ -55,13 +57,13 @@ const FileList = () => {
 
     return (
         <div className={classes.fileList} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-            <div className={classes.filesWrapper}>
-                <Dropzone onDrop={handleFilesSelected}>
+            <Dropzone onDrop={handleFilesSelected}>
+                <div className={classes.filesWrapper}>
                     {fileIds.map(fileId => (
                         <File file={filesById[fileId]} key={fileId} onDeleteFile={handleDeleteFile(fileId)} />
                     ))}
-                </Dropzone>
-            </div>
+                </div>
+            </Dropzone>
             {shouldDisplayClearButton && (
                 <IconButton className={classes.clearButton} label={t('clearFileList')} onClick={handleClearFiles}>
                     <ClearIcon />

--- a/src/components/FileStreams/FileStreams.js
+++ b/src/components/FileStreams/FileStreams.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import _ from 'lodash-es';
+import { Table, TableBody, TableCell, TableHead, TableRow, Tooltip } from '@material-ui/core';
+import AudioIcon from '@material-ui/icons/AudiotrackOutlined';
+import SubtitlesIcon from '@material-ui/icons/SubtitlesOutlined';
+import VideoIcon from '@material-ui/icons/MovieOutlined';
+import { makeStyles } from '@material-ui/core/styles';
+import i18n from '../../i18n';
+
+const useStyles = makeStyles({
+    codec: {
+        textTransform: 'uppercase',
+    },
+});
+
+const codecTypeIcons = {
+    audio: (
+        <Tooltip title={i18n.t('audio')}>
+            <AudioIcon />
+        </Tooltip>
+    ),
+    subtitle: (
+        <Tooltip title={i18n.t('subtitles')}>
+            <SubtitlesIcon />
+        </Tooltip>
+    ),
+    video: (
+        <Tooltip title={i18n.t('video')}>
+            <VideoIcon />
+        </Tooltip>
+    ),
+};
+
+const getStreamProperties = stream => {
+    const { bit_rate: bitRate, channels, codec_type: codecType, height, sample_rate: sampleRate, width } = stream;
+    switch (codecType) {
+        case 'audio':
+            return `${i18n.t('channel', { count: channels })}, ${
+                bitRate ? `${bitRate / 1000} kbps,` : ''
+            } ${sampleRate} Hz`;
+        case 'video':
+            return `${width}x${height}`;
+        default:
+            return '';
+    }
+};
+
+const FileStreams = ({ file }) => {
+    const { t } = useTranslation();
+    const classes = useStyles();
+    const streams = _.get(file, 'streams', []);
+
+    return (
+        <Table size="small">
+            <TableHead>
+                <TableRow>
+                    <TableCell>{t('conversionSettings.codec')}</TableCell>
+                    <TableCell>{t('type')}</TableCell>
+                    <TableCell>{t('language')}</TableCell>
+                    <TableCell>{t('title')}</TableCell>
+                    <TableCell>{t('properties')}</TableCell>
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {streams.map(stream => (
+                    <TableRow key={stream.index}>
+                        <TableCell className={classes.codec}>{stream.codec_name}</TableCell>
+                        <TableCell>{codecTypeIcons[stream.codec_type]}</TableCell>
+                        <TableCell>{stream.tags.language}</TableCell>
+                        <TableCell>{stream.tags.title}</TableCell>
+                        <TableCell>{getStreamProperties(stream)}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+};
+
+FileStreams.propTypes = {
+    file: PropTypes.object.isRequired,
+};
+
+export default FileStreams;

--- a/src/components/FileStreams/index.js
+++ b/src/components/FileStreams/index.js
@@ -1,0 +1,3 @@
+import FileStreams from './FileStreams';
+
+export default FileStreams;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,6 +1,9 @@
 {
     "translation": {
         "addFiles": "Add files",
+        "audio": "Audio",
+        "channel": "{{count}} channel",
+        "channel_plural": "{{count}} channels",
         "clearFileList": "Clear list",
         "close": "Close",
         "conversion": {
@@ -15,9 +18,15 @@
             "dropFiles": "Drop files here",
             "or": "or"
         },
+        "language": "Language",
+        "properties": "Properties",
         "removeFile": "Remove file",
         "sameAsSource": "Same as source",
         "selectDestination": "Select destination",
+        "subtitles": "Subtitles",
+        "title": "Title",
+        "type": "Type",
+        "video": "Video",
         "conversionSettings": {
             "aac": "AAC",
             "ac3": "AC3",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,6 +1,9 @@
 {
     "translation": {
         "addFiles": "Ajouter des fichiers",
+        "audio": "Audio",
+        "channel": "{{count}} canal",
+        "channel_plural": "{{count}} canaux",
         "clearFileList": "Effacer la liste",
         "close": "Fermer",
         "conversion": {
@@ -15,9 +18,15 @@
             "dropFiles": "Déposez des fichiers ici",
             "or": "ou"
         },
+        "language": "Langue",
+        "properties": "Propriétés",
         "removeFile": "Retirer le fichier",
         "sameAsSource": "Identique à la source",
         "selectDestination": "Sélectionner la destination",
+        "subtitles": "Sous-titres",
+        "title": "Title",
+        "type": "Type",
+        "video": "Vidéo",
         "conversionSettings": {
             "aac": "AAC",
             "ac3": "AC3",


### PR DESCRIPTION
## Description
Add a collapse panel in each file card to display streams info
![Jun-01-2020 03-09-26](https://user-images.githubusercontent.com/12082276/83367542-58a77900-a3b5-11ea-9c43-ed266c3acc83.gif)

## How to test

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] My change requires a change to the translations
- [x] I have updated the translation files accordingly
