### PR TITLE
feat(conversion): add & edit stream title

### DIFF
--- a/public/ffmpeg.js
+++ b/public/ffmpeg.js
@@ -35,6 +35,12 @@ const getIgnoredStreamsOptions = ignoredStreams => {
     return ignoredStreams.map(ignoredStreamIndex => `-map -0:${ignoredStreamIndex}`);
 };
 
+const getStreamsMetadataOptions = streamsMetadata => {
+    return streamsMetadata.map(({ index, key, value }) => {
+        return `-metadata:s:${index} ${key}=${value}`;
+    });
+};
+
 const getSingleOutputOption = (option, value) => {
     const optionFlag = OPTION_FLAGS[option];
     if (optionFlag) {
@@ -45,9 +51,10 @@ const getSingleOutputOption = (option, value) => {
 };
 
 const getOutputOptions = (options, file) => {
-    const { ignoredStreams } = file;
+    const { ignoredStreams, streamsMetadata } = file;
     const ignoredStreamsOptions = getIgnoredStreamsOptions(ignoredStreams);
-    const outputOptions = [...BASE_OUTPUT_OPTIONS, ...ignoredStreamsOptions];
+    const streamsMetadataOptions = getStreamsMetadataOptions(streamsMetadata);
+    const outputOptions = [...BASE_OUTPUT_OPTIONS, ...ignoredStreamsOptions, ...streamsMetadataOptions];
     Object.keys(options).forEach(optionKey => {
         const optionValue = options[optionKey];
         const outputOption = getSingleOutputOption(optionKey, optionValue);

--- a/src/components/FileStreams/FileStreams.js
+++ b/src/components/FileStreams/FileStreams.js
@@ -10,6 +10,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import i18n from '../../i18n';
 import { addStreamToIgnore, removeStreamToIgnore } from '../../store/file/file.actions';
 import { FILE_STATUS } from '../../store/file/file.constants';
+import StreamMetadataInput from '../StreamMetadataInput';
 
 const useStyles = makeStyles({
     codec: {
@@ -53,7 +54,7 @@ const FileStreams = ({ file }) => {
     const { t } = useTranslation();
     const dispatch = useDispatch();
     const classes = useStyles();
-    const { ignoredStreams, path, status, streams } = file;
+    const { ignoredStreams, path, status, streams, streamsMetadata } = file;
     const isEditDisabled = status === FILE_STATUS.converting || status === FILE_STATUS.complete;
 
     const handleCheckChange = useCallback(
@@ -95,7 +96,14 @@ const FileStreams = ({ file }) => {
                         <TableCell className={classes.codec}>{stream.codec_name}</TableCell>
                         <TableCell>{codecTypeIcons[stream.codec_type]}</TableCell>
                         <TableCell>{stream.tags.language}</TableCell>
-                        <TableCell>{stream.tags.title}</TableCell>
+                        <TableCell>
+                            <StreamMetadataInput
+                                filePath={path}
+                                name="title"
+                                stream={stream}
+                                streamsMetadata={streamsMetadata}
+                            />
+                        </TableCell>
                         <TableCell>{getStreamProperties(stream)}</TableCell>
                     </TableRow>
                 ))}

--- a/src/components/StreamMetadataInput/StreamMetadataInput.js
+++ b/src/components/StreamMetadataInput/StreamMetadataInput.js
@@ -1,0 +1,53 @@
+import React, { useCallback, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import _ from 'lodash-es';
+import { TextField, makeStyles } from '@material-ui/core';
+import { setStreamMetadata } from '../../store/file/file.actions';
+
+const useStyles = makeStyles({
+    textField: {
+        minWidth: 120,
+    },
+});
+
+const StreamMetadataInput = ({ filePath, name, stream, streamsMetadata }) => {
+    const classes = useStyles();
+    const dispatch = useDispatch();
+
+    const newMetadata = streamsMetadata.find(streamMetadata => {
+        return streamMetadata.index === stream.index && streamMetadata.key === name;
+    });
+
+    const inputValue = useMemo(() => {
+        return _.get(newMetadata, 'value', stream.tags[name]);
+    }, [name, newMetadata, stream.tags]);
+
+    const handleMetadataChange = useCallback(
+        streamIndex => event => {
+            const { value } = event.target;
+            dispatch(setStreamMetadata(filePath, streamIndex, name, value));
+        },
+        [dispatch, filePath, name],
+    );
+
+    return (
+        <TextField
+            className={classes.textField}
+            onChange={handleMetadataChange(stream.index)}
+            name={name}
+            size="small"
+            value={inputValue}
+            variant="outlined"
+        />
+    );
+};
+
+StreamMetadataInput.propTypes = {
+    filePath: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    stream: PropTypes.object.isRequired,
+    streamsMetadata: PropTypes.array.isRequired,
+};
+
+export default StreamMetadataInput;

--- a/src/components/StreamMetadataInput/index.js
+++ b/src/components/StreamMetadataInput/index.js
@@ -1,0 +1,3 @@
+import StreamMetadataInput from './StreamMetadataInput';
+
+export default StreamMetadataInput;

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -30,7 +30,7 @@
         "sameAsSource": "Identique à la source",
         "selectDestination": "Sélectionner la destination",
         "subtitles": "Sous-titres",
-        "title": "Title",
+        "title": "Titre",
         "type": "Type",
         "video": "Vidéo",
         "conversionSettings": {

--- a/src/store/file/file.actions.js
+++ b/src/store/file/file.actions.js
@@ -134,3 +134,27 @@ export const removeStreamToIgnore = (fileId, streamIndex) => (dispatch, getState
         dispatch({ files: file, type: UPDATE_FILES });
     }
 };
+
+export const setStreamMetadata = (fileId, streamIndex, metadataKey, metadataValue) => (dispatch, getState) => {
+    const filesById = getFilesById(getState());
+    const { streamsMetadata } = filesById[fileId];
+    const metadata = {
+        index: streamIndex,
+        key: metadataKey,
+        value: metadataValue,
+    };
+    const existingStreamMetadataIndex = streamsMetadata.findIndex(streamMetadata => {
+        return streamMetadata.index === streamIndex && streamMetadata.key === metadataKey;
+    });
+
+    if (existingStreamMetadataIndex !== -1) {
+        streamsMetadata[existingStreamMetadataIndex] = metadata;
+    } else {
+        streamsMetadata.push(metadata);
+    }
+    const file = {
+        ...filesById[fileId],
+        streamsMetadata,
+    };
+    dispatch({ files: file, type: UPDATE_FILES });
+};

--- a/src/store/file/file.utils.js
+++ b/src/store/file/file.utils.js
@@ -33,6 +33,7 @@ export const fileToObject = file => ({
     progress: 0,
     size: file.size,
     status: FILE_STATUS.initial,
+    streamsMetadata: [],
     type: file.type,
     webkitRelativePath: file.webkitRelativePath,
 });


### PR DESCRIPTION
## Description

## How to test
Launch the app, add a file to convert and display streams table.
Edit stream title inputs.
New titles should be visible in the output file.

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] My change requires a change to the translations
- [ ] I have updated the translation files accordingly
