### PR TITLE
fix(conversion): metadata on ignored stream

### DIFF
--- a/src/store/file/file.actions.js
+++ b/src/store/file/file.actions.js
@@ -108,6 +108,17 @@ export const setFileData = (fileId, fileData) => (dispatch, getState) => {
     dispatch({ files: file, type: UPDATE_FILES });
 };
 
+export const removeStreamMetadata = (fileId, streamIndex) => (dispatch, getState) => {
+    const filesById = getFilesById(getState());
+    const { streamsMetadata } = filesById[fileId];
+    const newStreamMetadata = streamsMetadata.filter(streamMetadata => streamMetadata.index !== streamIndex);
+    const file = {
+        ...filesById[fileId],
+        streamsMetadata: newStreamMetadata,
+    };
+    dispatch({ files: file, type: UPDATE_FILES });
+};
+
 export const addStreamToIgnore = (fileId, streamIndex) => (dispatch, getState) => {
     const filesById = getFilesById(getState());
     const { ignoredStreams } = filesById[fileId];
@@ -118,6 +129,7 @@ export const addStreamToIgnore = (fileId, streamIndex) => (dispatch, getState) =
             ignoredStreams,
         };
         dispatch({ files: file, type: UPDATE_FILES });
+        dispatch(removeStreamMetadata(fileId, streamIndex));
     }
 };
 


### PR DESCRIPTION
## Description
Metadata added on an ignored stream is added to the next stream in the output file.
I added a `removeStreamMetadata` action to remove all metadata related to a stream when it's ignored.

## How to test
Start the app, add a file and add/change a stream title in the file streams table then unchecked a stream to ignore it. It should reset the title to the initial title and metadata should not be present in the output file after running the conversion

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the translations
- [ ] I have updated the translation files accordingly
<!---
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
--->
